### PR TITLE
step2: refactor, move error and consts

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -96,8 +96,8 @@ jobs:
     - name: Install hax and F* (Fstar)
       uses: hacspec/hax-actions@main
       with:
-        # pin hax to known-working
-        hax_reference: "87ba96831ecfeb7dbb54efcf97036fbc5f25bc71"
+        # pin hax to known-working (0.3.7)
+        hax_reference: "d8b5b3d3b666fee8943a351445d2b680105e8ea3"
         fstar: v2025.10.06
 
     - name: Hax extract from lakers and lakers-shared into F* (Fstar)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -173,7 +173,7 @@ jobs:
     - name: Install libcoap
       run: |
         cd libcoap && ./autogen.sh
-        ./configure --disable-doxygen --disable-manpages --disable-dtls --disable-oscore
+        ./configure --disable-doxygen --disable-manpages --disable-dtls --disable-oscore --disable-examples
         make && sudo make install
 
     - name: Install arm targets for Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ lakers-crypto-rustcrypto = { package = "lakers-crypto-rustcrypto", path = "crypt
 lakers = { package = "lakers", path = "lib/", version = "^0.8.0", default-features = false }
 
 # Beware that those two lines are mogrified in CI so that hax can find the proof-libs through the git path:
-hax-lib = { version = "0.3.1", default-features = false, features = ["macros"] }
+hax-lib = { version = "0.3.7", default-features = false, features = ["macros"] }
 # to get proof-libs: hax-lib = { git = "https://github.com/cryspen/hax", default-features = false, features = ["macros"] }
 
 [patch.crates-io]

--- a/shared/src/consts.rs
+++ b/shared/src/consts.rs
@@ -1,0 +1,110 @@
+// When changing this, beware that it is re-implemented in cbindgen.toml
+pub const MAX_MESSAGE_SIZE_LEN: usize = if cfg!(feature = "max_message_size_len_1024") {
+    1024
+} else if cfg!(feature = "max_message_size_len_512") {
+    512
+} else if cfg!(feature = "max_message_size_len_448") {
+    448
+} else if cfg!(feature = "max_message_size_len_384") {
+    384
+} else if cfg!(feature = "max_message_size_len_320") {
+    320
+} else if cfg!(feature = "max_message_size_len_256") {
+    256
+} else {
+    // need 128 to handle EAD fields, and 192 for the EAD_1 voucher
+    128 + 64
+};
+
+pub const ID_CRED_LEN: usize = 4;
+pub const SUITES_LEN: usize = 9;
+pub const SUPPORTED_SUITES_LEN: usize = 1;
+pub const EDHOC_METHOD: u8 = 3u8; // stat-stat is the only supported method
+pub const P256_ELEM_LEN: usize = 32;
+pub const ELEM_LEN_PSK: usize = 16;
+pub const SHA256_DIGEST_LEN: usize = 32;
+pub const AES_CCM_KEY_LEN: usize = 16;
+pub const AES_CCM_IV_LEN: usize = 13;
+pub const AES_CCM_TAG_LEN: usize = 8;
+pub const MAC_LENGTH: usize = 8; // used for EAD Zeroconf
+pub const MAC_LENGTH_2: usize = MAC_LENGTH;
+pub const MAC_LENGTH_3: usize = MAC_LENGTH_2;
+pub const VOUCHER_LEN: usize = MAC_LENGTH;
+pub const MAX_EAD_ITEMS: usize = 4;
+
+// maximum supported length of connection identifier for R
+//
+// When changing this, beware that it is re-implemented in cbindgen.toml
+pub const MAX_KDF_CONTEXT_LEN: usize = if cfg!(feature = "max_kdf_content_len_1024") {
+    1024
+} else if cfg!(feature = "max_kdf_content_len_512") {
+    512
+} else if cfg!(feature = "max_kdf_content_len_448") {
+    448
+} else if cfg!(feature = "max_kdf_content_len_384") {
+    384
+} else if cfg!(feature = "max_kdf_content_len_320") {
+    320
+} else {
+    256
+};
+pub const MAX_KDF_LABEL_LEN: usize = 15; // for "KEYSTREAM_2"
+
+// When changing this, beware that it is re-implemented in cbindgen.toml
+pub const MAX_BUFFER_LEN: usize = if cfg!(feature = "max_buffer_len_1024") {
+    1024
+} else if cfg!(feature = "max_buffer_len_512") {
+    512
+} else if cfg!(feature = "max_buffer_len_448") {
+    448
+} else if cfg!(feature = "max_buffer_len_384") {
+    384
+} else {
+    256 + 64
+};
+pub const CBOR_BYTE_STRING: u8 = 0x58u8;
+pub const CBOR_TEXT_STRING: u8 = 0x78u8;
+pub const CBOR_UINT_1BYTE: u8 = 0x18u8;
+pub const CBOR_NEG_INT_1BYTE_START: u8 = 0x20u8;
+pub const CBOR_NEG_INT_1BYTE_END: u8 = 0x37u8;
+pub const CBOR_UINT_1BYTE_START: u8 = 0x0u8;
+pub const CBOR_UINT_1BYTE_END: u8 = 0x17u8;
+pub const CBOR_MAJOR_UNSIGNED: u8 = 0 << 5;
+pub const CBOR_MAJOR_NEGATIVE: u8 = 1 << 5;
+pub const CBOR_MAJOR_TAG: u8 = 6 << 5;
+pub const CBOR_MAJOR_FLOATSIMPLE: u8 = 7 << 5;
+pub const CBOR_MAJOR_TEXT_STRING: u8 = 0x60u8;
+pub const CBOR_MAJOR_BYTE_STRING: u8 = 0x40u8;
+pub const CBOR_MAJOR_BYTE_STRING_MAX: u8 = 0x57u8;
+pub const CBOR_MAJOR_ARRAY: u8 = 0x80u8;
+pub const CBOR_MAJOR_ARRAY_MAX: u8 = 0x97u8;
+pub const CBOR_MAJOR_MAP: u8 = 0xA0;
+pub const MAX_INFO_LEN: usize = 2 + SHA256_DIGEST_LEN + // 32-byte digest as bstr
+				            1 + MAX_KDF_LABEL_LEN +     // label <24 bytes as tstr
+						    1 + MAX_KDF_CONTEXT_LEN +   // context <24 bytes as bstr
+						    1; // length as u8
+
+pub const KCCS_LABEL: u8 = 14;
+#[deprecated(note = "Typo for KCCS_LABEL")]
+pub const KCSS_LABEL: u8 = KCCS_LABEL;
+pub const KID_LABEL: u8 = 4;
+
+pub const ENC_STRUCTURE_LEN: usize = 8 + 5 + SHA256_DIGEST_LEN; // 8 for ENCRYPT0
+
+pub const MAX_EAD_LEN: usize = if cfg!(feature = "max_ead_len_1024") {
+    1024
+} else if cfg!(feature = "max_ead_len_768") {
+    768
+} else if cfg!(feature = "max_ead_len_512") {
+    512
+} else if cfg!(feature = "max_ead_len_384") {
+    384
+} else if cfg!(feature = "max_ead_len_256") {
+    256
+} else if cfg!(feature = "max_ead_len_192") {
+    192
+} else if cfg!(feature = "max_ead_len_128") {
+    128
+} else {
+    64
+};

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -1,0 +1,75 @@
+use core::num::NonZeroI16;
+#[derive(PartialEq, Debug)]
+#[non_exhaustive]
+pub enum EDHOCError {
+    /// In an exchange, a credential was set as "expected", but the credential configured by the
+    /// peer did not match what was presented. This is more an application internal than an EDHOC
+    /// error: When the application sets the expected credential, that process should be informed
+    /// by the known details.
+    UnexpectedCredential,
+    MissingIdentity,
+    IdentityAlreadySet,
+    MacVerificationFailed,
+    UnsupportedMethod,
+    UnsupportedCipherSuite,
+    ParsingError,
+    EncodingError,
+    CredentialTooLongError,
+    EadLabelTooLongError,
+    EadTooLongError,
+    /// An EAD was received that was either not known (and critical), or not understood, or
+    /// otherwise erroneous.
+    EADUnprocessable,
+    /// The credential or EADs could be processed (possibly by a third party), but the decision
+    /// based on that was to not to continue the EDHOC session.
+    ///
+    /// See also
+    /// <https://datatracker.ietf.org/doc/html/draft-ietf-lake-authz#name-edhoc-error-access-denied>
+    AccessDenied,
+}
+
+impl EDHOCError {
+    /// The ERR_CODE corresponding to the error
+    ///
+    /// Errors that refer to internal limitations (such as EadTooLongError) are treated the same
+    /// way as parsing errors, and return an unspecified error: Those are equivalent to limitations
+    /// of the parser, and a constrained system can not be expected to differentiate between "the
+    /// standard allows this but my number space is too small" and "this violates the standard".
+    ///
+    /// If an EDHOCError is returned through EDHOC, it will use this in its EDHOC error message.
+    ///
+    /// Note that this on its own is insufficient to create an error message: Additional ERR_INFO
+    /// is needed, which may or may not be available with the EDHOCError alone.
+    ///
+    /// TODO: Evolve the EDHOCError type such that all information needed is available.
+    pub fn err_code(&self) -> ErrCode {
+        use EDHOCError::*;
+        match self {
+            UnexpectedCredential => ErrCode::UNSPECIFIED,
+            MissingIdentity => ErrCode::UNSPECIFIED,
+            IdentityAlreadySet => ErrCode::UNSPECIFIED,
+            MacVerificationFailed => ErrCode::UNSPECIFIED,
+            UnsupportedMethod => ErrCode::UNSPECIFIED,
+            UnsupportedCipherSuite => ErrCode::WRONG_SELECTED_CIPHER_SUITE,
+            ParsingError => ErrCode::UNSPECIFIED,
+            EncodingError => ErrCode::UNSPECIFIED,
+            CredentialTooLongError => ErrCode::UNSPECIFIED,
+            EadLabelTooLongError => ErrCode::UNSPECIFIED,
+            EadTooLongError => ErrCode::UNSPECIFIED,
+            EADUnprocessable => ErrCode::UNSPECIFIED,
+            AccessDenied => ErrCode::ACCESS_DENIED,
+        }
+    }
+}
+
+/// Representation of an EDHOC ERR_CODE
+#[repr(C)]
+pub struct ErrCode(pub NonZeroI16);
+
+impl ErrCode {
+    pub const UNSPECIFIED: Self = ErrCode(NonZeroI16::new(1).unwrap());
+    pub const WRONG_SELECTED_CIPHER_SUITE: Self = ErrCode(NonZeroI16::new(2).unwrap());
+    pub const UNKNOWN_CREDENTIAL: Self = ErrCode(NonZeroI16::new(3).unwrap());
+    // Code requested in https://datatracker.ietf.org/doc/html/draft-ietf-lake-authz
+    pub const ACCESS_DENIED: Self = ErrCode(NonZeroI16::new(3333).unwrap());
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -27,122 +27,13 @@ pub use cred::*;
 mod buffer;
 pub use buffer::*;
 
+pub mod consts;
+pub use consts::*;
+
 #[cfg(feature = "python-bindings")]
 use pyo3::prelude::*;
 #[cfg(feature = "python-bindings")]
 mod python_bindings;
-
-// When changing this, beware that it is re-implemented in cbindgen.toml
-pub const MAX_MESSAGE_SIZE_LEN: usize = if cfg!(feature = "max_message_size_len_1024") {
-    1024
-} else if cfg!(feature = "max_message_size_len_512") {
-    512
-} else if cfg!(feature = "max_message_size_len_448") {
-    448
-} else if cfg!(feature = "max_message_size_len_384") {
-    384
-} else if cfg!(feature = "max_message_size_len_320") {
-    320
-} else if cfg!(feature = "max_message_size_len_256") {
-    256
-} else {
-    // need 128 to handle EAD fields, and 192 for the EAD_1 voucher
-    128 + 64
-};
-
-pub const ID_CRED_LEN: usize = 4;
-pub const SUITES_LEN: usize = 9;
-pub const SUPPORTED_SUITES_LEN: usize = 1;
-pub const EDHOC_METHOD: u8 = 3u8; // stat-stat is the only supported method
-pub const P256_ELEM_LEN: usize = 32;
-pub const ELEM_LEN_PSK: usize = 16;
-pub const SHA256_DIGEST_LEN: usize = 32;
-pub const AES_CCM_KEY_LEN: usize = 16;
-pub const AES_CCM_IV_LEN: usize = 13;
-pub const AES_CCM_TAG_LEN: usize = 8;
-pub const MAC_LENGTH: usize = 8; // used for EAD Zeroconf
-pub const MAC_LENGTH_2: usize = MAC_LENGTH;
-pub const MAC_LENGTH_3: usize = MAC_LENGTH_2;
-pub const VOUCHER_LEN: usize = MAC_LENGTH;
-pub const MAX_EAD_ITEMS: usize = 4;
-
-// maximum supported length of connection identifier for R
-//
-// When changing this, beware that it is re-implemented in cbindgen.toml
-pub const MAX_KDF_CONTEXT_LEN: usize = if cfg!(feature = "max_kdf_content_len_1024") {
-    1024
-} else if cfg!(feature = "max_kdf_content_len_512") {
-    512
-} else if cfg!(feature = "max_kdf_content_len_448") {
-    448
-} else if cfg!(feature = "max_kdf_content_len_384") {
-    384
-} else if cfg!(feature = "max_kdf_content_len_320") {
-    320
-} else {
-    256
-};
-pub const MAX_KDF_LABEL_LEN: usize = 15; // for "KEYSTREAM_2"
-
-// When changing this, beware that it is re-implemented in cbindgen.toml
-pub const MAX_BUFFER_LEN: usize = if cfg!(feature = "max_buffer_len_1024") {
-    1024
-} else if cfg!(feature = "max_buffer_len_512") {
-    512
-} else if cfg!(feature = "max_buffer_len_448") {
-    448
-} else if cfg!(feature = "max_buffer_len_384") {
-    384
-} else {
-    256 + 64
-};
-pub const CBOR_BYTE_STRING: u8 = 0x58u8;
-pub const CBOR_TEXT_STRING: u8 = 0x78u8;
-pub const CBOR_UINT_1BYTE: u8 = 0x18u8;
-pub const CBOR_NEG_INT_1BYTE_START: u8 = 0x20u8;
-pub const CBOR_NEG_INT_1BYTE_END: u8 = 0x37u8;
-pub const CBOR_UINT_1BYTE_START: u8 = 0x0u8;
-pub const CBOR_UINT_1BYTE_END: u8 = 0x17u8;
-const CBOR_MAJOR_UNSIGNED: u8 = 0 << 5;
-const CBOR_MAJOR_NEGATIVE: u8 = 1 << 5;
-const CBOR_MAJOR_TAG: u8 = 6 << 5;
-const CBOR_MAJOR_FLOATSIMPLE: u8 = 7 << 5;
-pub const CBOR_MAJOR_TEXT_STRING: u8 = 0x60u8;
-pub const CBOR_MAJOR_BYTE_STRING: u8 = 0x40u8;
-pub const CBOR_MAJOR_BYTE_STRING_MAX: u8 = 0x57u8;
-pub const CBOR_MAJOR_ARRAY: u8 = 0x80u8;
-pub const CBOR_MAJOR_ARRAY_MAX: u8 = 0x97u8;
-pub const CBOR_MAJOR_MAP: u8 = 0xA0;
-pub const MAX_INFO_LEN: usize = 2 + SHA256_DIGEST_LEN + // 32-byte digest as bstr
-				            1 + MAX_KDF_LABEL_LEN +     // label <24 bytes as tstr
-						    1 + MAX_KDF_CONTEXT_LEN +   // context <24 bytes as bstr
-						    1; // length as u8
-
-pub const KCCS_LABEL: u8 = 14;
-#[deprecated(note = "Typo for KCCS_LABEL")]
-pub const KCSS_LABEL: u8 = KCCS_LABEL;
-pub const KID_LABEL: u8 = 4;
-
-pub const ENC_STRUCTURE_LEN: usize = 8 + 5 + SHA256_DIGEST_LEN; // 8 for ENCRYPT0
-pub const ENC_STRUCTURE_PSK_LEN: usize = 1 + 1 + 8 + 1 + EXTERNAL_AAD_PSK_LEN; //
-pub const EXTERNAL_AAD_PSK_LEN: usize = 1 + 1 + 2 + 32 + 2 + 38 + 2 + 38 + 1;
-pub const MAX_EAD_LEN: usize = if cfg!(feature = "max_ead_len_1024") {
-    1024
-} else if cfg!(feature = "max_ead_len_768") {
-    768
-} else if cfg!(feature = "max_ead_len_512") {
-    512
-} else if cfg!(feature = "max_ead_len_384") {
-    384
-} else if cfg!(feature = "max_ead_len_256") {
-    256
-} else if cfg!(feature = "max_ead_len_192") {
-    192
-} else if cfg!(feature = "max_ead_len_128") {
-    128
-} else {
-    64
-};
 
 /// Maximum length of a [`ConnId`] (`C_x`).
 ///

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -15,7 +15,6 @@ pub use cbor_decoder::*;
 pub use edhoc_parser::*;
 pub use helpers::*;
 
-use core::num::NonZeroI16;
 use defmt_or_log::trace;
 
 mod crypto;
@@ -29,6 +28,9 @@ pub use buffer::*;
 
 pub mod consts;
 pub use consts::*;
+
+mod error;
+pub use error::{EDHOCError, ErrCode};
 
 #[cfg(feature = "python-bindings")]
 use pyo3::prelude::*;
@@ -292,81 +294,6 @@ impl From<EDHOCSuite> for u8 {
     fn from(suite: EDHOCSuite) -> u8 {
         suite as u8
     }
-}
-
-#[derive(PartialEq, Debug)]
-#[non_exhaustive]
-pub enum EDHOCError {
-    /// In an exchange, a credential was set as "expected", but the credential configured by the
-    /// peer did not match what was presented. This is more an application internal than an EDHOC
-    /// error: When the application sets the expected credential, that process should be informed
-    /// by the known details.
-    UnexpectedCredential,
-    MissingIdentity,
-    IdentityAlreadySet,
-    MacVerificationFailed,
-    UnsupportedMethod,
-    UnsupportedCipherSuite,
-    ParsingError,
-    EncodingError,
-    CredentialTooLongError,
-    EadLabelTooLongError,
-    EadTooLongError,
-    /// An EAD was received that was either not known (and critical), or not understood, or
-    /// otherwise erroneous.
-    EADUnprocessable,
-    /// The credential or EADs could be processed (possibly by a third party), but the decision
-    /// based on that was to not to continue the EDHOC session.
-    ///
-    /// See also
-    /// <https://datatracker.ietf.org/doc/html/draft-ietf-lake-authz#name-edhoc-error-access-denied>
-    AccessDenied,
-}
-
-impl EDHOCError {
-    /// The ERR_CODE corresponding to the error
-    ///
-    /// Errors that refer to internal limitations (such as EadTooLongError) are treated the same
-    /// way as parsing errors, and return an unspecified error: Those are equivalent to limitations
-    /// of the parser, and a constrained system can not be expected to differentiate between "the
-    /// standard allows this but my number space is too small" and "this violates the standard".
-    ///
-    /// If an EDHOCError is returned through EDHOC, it will use this in its EDHOC error message.
-    ///
-    /// Note that this on its own is insufficient to create an error message: Additional ERR_INFO
-    /// is needed, which may or may not be available with the EDHOCError alone.
-    ///
-    /// TODO: Evolve the EDHOCError type such that all information needed is available.
-    pub fn err_code(&self) -> ErrCode {
-        use EDHOCError::*;
-        match self {
-            UnexpectedCredential => ErrCode::UNSPECIFIED,
-            MissingIdentity => ErrCode::UNSPECIFIED,
-            IdentityAlreadySet => ErrCode::UNSPECIFIED,
-            MacVerificationFailed => ErrCode::UNSPECIFIED,
-            UnsupportedMethod => ErrCode::UNSPECIFIED,
-            UnsupportedCipherSuite => ErrCode::WRONG_SELECTED_CIPHER_SUITE,
-            ParsingError => ErrCode::UNSPECIFIED,
-            EncodingError => ErrCode::UNSPECIFIED,
-            CredentialTooLongError => ErrCode::UNSPECIFIED,
-            EadLabelTooLongError => ErrCode::UNSPECIFIED,
-            EadTooLongError => ErrCode::UNSPECIFIED,
-            EADUnprocessable => ErrCode::UNSPECIFIED,
-            AccessDenied => ErrCode::ACCESS_DENIED,
-        }
-    }
-}
-
-/// Representation of an EDHOC ERR_CODE
-#[repr(C)]
-pub struct ErrCode(pub NonZeroI16);
-
-impl ErrCode {
-    pub const UNSPECIFIED: Self = ErrCode(NonZeroI16::new(1).unwrap());
-    pub const WRONG_SELECTED_CIPHER_SUITE: Self = ErrCode(NonZeroI16::new(2).unwrap());
-    pub const UNKNOWN_CREDENTIAL: Self = ErrCode(NonZeroI16::new(3).unwrap());
-    // Code requested in https://datatracker.ietf.org/doc/html/draft-ietf-lake-authz
-    pub const ACCESS_DENIED: Self = ErrCode(NonZeroI16::new(3333).unwrap());
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Just running here so  I can see the CI result


Just move Consts and Errors for standalone modules


The reason for that is:
when there is circular dependencies, the hax to F* takes both modules and makes a Lakers_shared.Bundle to prove both together, since everything are downstream from the constants and the error module, make sense trying to make them separate so I start proving panic freedom step by step