### PR TITLE
step 4: prove cred + cbor_decoder

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -96,8 +96,8 @@ jobs:
     - name: Install hax and F* (Fstar)
       uses: hacspec/hax-actions@main
       with:
-        # pin hax to known-working
-        hax_reference: "87ba96831ecfeb7dbb54efcf97036fbc5f25bc71"
+        # pin hax to known-working (0.3.7)
+        hax_reference: "d8b5b3d3b666fee8943a351445d2b680105e8ea3"
         fstar: v2025.10.06
 
     - name: Hax extract from lakers and lakers-shared into F* (Fstar)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,7 +123,7 @@ jobs:
       working-directory: ./shared/proofs/fstar/extraction
       run: |
         curl -o Makefile https://gist.githubusercontent.com/W95Psp/4c304132a1f85c5af4e4959dd6b356c3/raw/Makefile
-        ROOTS=Lakers_shared.Buffer.fst make verify
+        ROOTS="Lakers_shared.Buffer.fst Lakers_shared.Error.fst Lakers_shared.Consts.fst" make verify
 
   build-lakers-c:
     needs: unit-tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,7 +123,7 @@ jobs:
       working-directory: ./shared/proofs/fstar/extraction
       run: |
         curl -o Makefile https://gist.githubusercontent.com/W95Psp/4c304132a1f85c5af4e4959dd6b356c3/raw/Makefile
-        ROOTS="Lakers_shared.Buffer.fst Lakers_shared.Error.fst Lakers_shared.Consts.fst" make verify
+        ROOTS="Lakers_shared.Buffer.fst Lakers_shared.Error.fst Lakers_shared.Consts.fst Lakers_shared.Cbor_decoder.fst" make verify
 
   build-lakers-c:
     needs: unit-tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -173,7 +173,7 @@ jobs:
     - name: Install libcoap
       run: |
         cd libcoap && ./autogen.sh
-        ./configure --disable-doxygen --disable-manpages --disable-dtls --disable-oscore
+        ./configure --disable-doxygen --disable-manpages --disable-dtls --disable-oscore --disable-examples
         make && sudo make install
 
     - name: Install arm targets for Rust

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,7 +123,7 @@ jobs:
       working-directory: ./shared/proofs/fstar/extraction
       run: |
         curl -o Makefile https://gist.githubusercontent.com/W95Psp/4c304132a1f85c5af4e4959dd6b356c3/raw/Makefile
-        ROOTS="Lakers_shared.Buffer.fst Lakers_shared.Error.fst Lakers_shared.Consts.fst Lakers_shared.Cbor_decoder.fst" make verify
+        ROOTS="Lakers_shared.Buffer.fst Lakers_shared.Error.fst Lakers_shared.Consts.fst Lakers_shared.Cbor_decoder.fst Lakers_shared.Cred.fst" make verify
 
   build-lakers-c:
     needs: unit-tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ lakers-crypto-rustcrypto = { package = "lakers-crypto-rustcrypto", path = "crypt
 lakers = { package = "lakers", path = "lib/", version = "^0.8.0", default-features = false }
 
 # Beware that those two lines are mogrified in CI so that hax can find the proof-libs through the git path:
-hax-lib = { version = "0.3.1", default-features = false, features = ["macros"] }
+hax-lib = { version = "0.3.7", default-features = false, features = ["macros"] }
 # to get proof-libs: hax-lib = { git = "https://github.com/cryspen/hax", default-features = false, features = ["macros"] }
 
 [patch.crates-io]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -544,7 +544,7 @@ pub fn credential_check_or_fetch(
         // 1. Does ID_CRED_X point to a stored authentication credential? YES
         // IMPL: compare cred_i_expected with id_cred
         //   IMPL: assume cred_i_expected is well formed
-        let credentials_match = if id_cred_received.reference_only() {
+        let credentials_match = if id_cred_received.reference_only()? {
             id_cred_received.as_full_value() == cred_expected.by_kid()?.as_full_value()
         } else {
             id_cred_received.as_full_value() == cred_expected.by_value()?.as_full_value()
@@ -1005,7 +1005,7 @@ mod test_authz {
             .unwrap();
         let _initiator = initiator.completed_without_message_4();
         let (responder, id_cred_i, _ead_3) = responder.parse_message_3(&message_3).unwrap();
-        let valid_cred_i = if id_cred_i.reference_only() {
+        let valid_cred_i = if id_cred_i.reference_only().unwrap() {
             mock_fetch_cred_i(id_cred_i).unwrap()
         } else {
             id_cred_i.get_ccs().unwrap()

--- a/shared/src/consts.rs
+++ b/shared/src/consts.rs
@@ -1,0 +1,110 @@
+// When changing this, beware that it is re-implemented in cbindgen.toml
+pub const MAX_MESSAGE_SIZE_LEN: usize = if cfg!(feature = "max_message_size_len_1024") {
+    1024
+} else if cfg!(feature = "max_message_size_len_512") {
+    512
+} else if cfg!(feature = "max_message_size_len_448") {
+    448
+} else if cfg!(feature = "max_message_size_len_384") {
+    384
+} else if cfg!(feature = "max_message_size_len_320") {
+    320
+} else if cfg!(feature = "max_message_size_len_256") {
+    256
+} else {
+    // need 128 to handle EAD fields, and 192 for the EAD_1 voucher
+    128 + 64
+};
+
+pub const ID_CRED_LEN: usize = 4;
+pub const SUITES_LEN: usize = 9;
+pub const SUPPORTED_SUITES_LEN: usize = 1;
+pub const EDHOC_METHOD: u8 = 3u8; // stat-stat is the only supported method
+pub const P256_ELEM_LEN: usize = 32;
+pub const ELEM_LEN_PSK: usize = 16;
+pub const SHA256_DIGEST_LEN: usize = 32;
+pub const AES_CCM_KEY_LEN: usize = 16;
+pub const AES_CCM_IV_LEN: usize = 13;
+pub const AES_CCM_TAG_LEN: usize = 8;
+pub const MAC_LENGTH: usize = 8; // used for EAD Zeroconf
+pub const MAC_LENGTH_2: usize = MAC_LENGTH;
+pub const MAC_LENGTH_3: usize = MAC_LENGTH_2;
+pub const VOUCHER_LEN: usize = MAC_LENGTH;
+pub const MAX_EAD_ITEMS: usize = 4;
+
+// maximum supported length of connection identifier for R
+//
+// When changing this, beware that it is re-implemented in cbindgen.toml
+pub const MAX_KDF_CONTEXT_LEN: usize = if cfg!(feature = "max_kdf_content_len_1024") {
+    1024
+} else if cfg!(feature = "max_kdf_content_len_512") {
+    512
+} else if cfg!(feature = "max_kdf_content_len_448") {
+    448
+} else if cfg!(feature = "max_kdf_content_len_384") {
+    384
+} else if cfg!(feature = "max_kdf_content_len_320") {
+    320
+} else {
+    256
+};
+pub const MAX_KDF_LABEL_LEN: usize = 15; // for "KEYSTREAM_2"
+
+// When changing this, beware that it is re-implemented in cbindgen.toml
+pub const MAX_BUFFER_LEN: usize = if cfg!(feature = "max_buffer_len_1024") {
+    1024
+} else if cfg!(feature = "max_buffer_len_512") {
+    512
+} else if cfg!(feature = "max_buffer_len_448") {
+    448
+} else if cfg!(feature = "max_buffer_len_384") {
+    384
+} else {
+    256 + 64
+};
+pub const CBOR_BYTE_STRING: u8 = 0x58u8;
+pub const CBOR_TEXT_STRING: u8 = 0x78u8;
+pub const CBOR_UINT_1BYTE: u8 = 0x18u8;
+pub const CBOR_NEG_INT_1BYTE_START: u8 = 0x20u8;
+pub const CBOR_NEG_INT_1BYTE_END: u8 = 0x37u8;
+pub const CBOR_UINT_1BYTE_START: u8 = 0x0u8;
+pub const CBOR_UINT_1BYTE_END: u8 = 0x17u8;
+pub const CBOR_MAJOR_UNSIGNED: u8 = 0 << 5;
+pub const CBOR_MAJOR_NEGATIVE: u8 = 1 << 5;
+pub const CBOR_MAJOR_TAG: u8 = 6 << 5;
+pub const CBOR_MAJOR_FLOATSIMPLE: u8 = 7 << 5;
+pub const CBOR_MAJOR_TEXT_STRING: u8 = 0x60u8;
+pub const CBOR_MAJOR_BYTE_STRING: u8 = 0x40u8;
+pub const CBOR_MAJOR_BYTE_STRING_MAX: u8 = 0x57u8;
+pub const CBOR_MAJOR_ARRAY: u8 = 0x80u8;
+pub const CBOR_MAJOR_ARRAY_MAX: u8 = 0x97u8;
+pub const CBOR_MAJOR_MAP: u8 = 0xA0;
+pub const MAX_INFO_LEN: usize = 2 + SHA256_DIGEST_LEN + // 32-byte digest as bstr
+				            1 + MAX_KDF_LABEL_LEN +     // label <24 bytes as tstr
+						    1 + MAX_KDF_CONTEXT_LEN +   // context <24 bytes as bstr
+						    1; // length as u8
+
+pub const KCCS_LABEL: u8 = 14;
+#[deprecated(note = "Typo for KCCS_LABEL")]
+pub const KCSS_LABEL: u8 = KCCS_LABEL;
+pub const KID_LABEL: u8 = 4;
+
+pub const ENC_STRUCTURE_LEN: usize = 8 + 5 + SHA256_DIGEST_LEN; // 8 for ENCRYPT0
+
+pub const MAX_EAD_LEN: usize = if cfg!(feature = "max_ead_len_1024") {
+    1024
+} else if cfg!(feature = "max_ead_len_768") {
+    768
+} else if cfg!(feature = "max_ead_len_512") {
+    512
+} else if cfg!(feature = "max_ead_len_384") {
+    384
+} else if cfg!(feature = "max_ead_len_256") {
+    256
+} else if cfg!(feature = "max_ead_len_192") {
+    192
+} else if cfg!(feature = "max_ead_len_128") {
+    128
+} else {
+    64
+};

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -1,8 +1,12 @@
 use super::*;
 
-pub type BufferCred = EdhocBuffer<192>; // arbitrary size
-pub type BufferKid = EdhocBuffer<16>; // variable size, up to 16 bytes
-pub type BufferIdCred = EdhocBuffer<192>; // variable size, can contain either the contents of a BufferCred or a BufferKid
+pub const BUFFER_CRED_LEN: usize = 192; // arbitrary size
+pub const BUFFER_ID_CRED_LEN: usize = 192; // variable size, can contain either the contents of a BufferCred or a BufferKid
+pub const BUFFER_KID_LEN: usize = 16; // variable size, up to 16 bytes
+
+pub type BufferCred = EdhocBuffer<BUFFER_CRED_LEN>;
+pub type BufferKid = EdhocBuffer<BUFFER_KID_LEN>;
+pub type BufferIdCred = EdhocBuffer<BUFFER_ID_CRED_LEN>;
 pub type BytesKeyAES128 = [u8; 16];
 pub type BytesKeyEC2 = [u8; 32];
 
@@ -158,7 +162,7 @@ impl IdCred {
     }
 
     fn bstr_representable_as_int(value: u8) -> bool {
-        (0x0..=0x17).contains(&value) || (0x20..=0x37).contains(&value)
+        value <= 0x17 || (value >= 0x20 && value <= 0x37)
     }
 }
 

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -29,12 +29,13 @@ pub enum IdCredType {
     KCCS = 14,
 }
 
-impl From<u8> for IdCredType {
-    fn from(value: u8) -> Self {
+impl TryFrom<u8> for IdCredType {
+    type Error = EDHOCError;
+    fn try_from(value: u8) -> Result<Self, EDHOCError> {
         match value {
-            4 => IdCredType::KID,
-            14 => IdCredType::KCCS,
-            _ => panic!("Invalid IdCredType"),
+            4 => Ok(IdCredType::KID),
+            14 => Ok(IdCredType::KCCS),
+            _ => Err(EDHOCError::ParsingError),
         }
     }
 }
@@ -140,16 +141,16 @@ impl IdCred {
         }
     }
 
-    pub fn reference_only(&self) -> bool {
-        [IdCredType::KID].contains(&self.item_type())
+    pub fn reference_only(&self) -> Result<bool, EDHOCError> {
+        Ok(self.item_type()? == IdCredType::KID)
     }
 
-    pub fn item_type(&self) -> IdCredType {
-        self.bytes.as_slice()[1].into()
+    fn item_type(&self) -> Result<IdCredType, EDHOCError> {
+        self.bytes[1].try_into()
     }
 
     pub fn get_ccs(&self) -> Option<Credential> {
-        if self.item_type() == IdCredType::KCCS {
+        if self.item_type() == Ok(IdCredType::KCCS) {
             Credential::parse_ccs(&self.bytes.as_slice()[2..]).ok()
         } else {
             None
@@ -489,10 +490,10 @@ mod test {
             .with_kid(KID_VALUE_TV.try_into().unwrap());
         let id_cred = cred.by_value().unwrap();
         assert_eq!(id_cred.bytes.as_slice(), ID_CRED_BY_VALUE_TV);
-        assert_eq!(id_cred.item_type(), IdCredType::KCCS);
+        assert_eq!(id_cred.item_type(), Ok(IdCredType::KCCS));
         let id_cred = cred.by_kid().unwrap();
         assert_eq!(id_cred.bytes.as_slice(), ID_CRED_BY_REF_TV);
-        assert_eq!(id_cred.item_type(), IdCredType::KID);
+        assert_eq!(id_cred.item_type(), Ok(IdCredType::KID));
     }
 
     #[test]

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -65,6 +65,7 @@ pub struct IdCred {
     pub bytes: BufferIdCred, // variable size, can contain either the contents of a BufferCred or a BufferKid
 }
 
+#[hax_lib::attributes]
 impl IdCred {
     pub fn new() -> Self {
         Self {
@@ -120,6 +121,7 @@ impl IdCred {
     /// View the full value of the ID_CRED_x: the CBOR encoding of a 1-element CBOR map
     ///
     /// This is the value that is used when ID_CRED_x has no impact on message size, see RFC 9528 Section 3.5.3.2.
+    #[hax_lib::requires(self.bytes.len() <= BUFFER_ID_CRED_LEN)]
     pub fn as_full_value(&self) -> &[u8] {
         self.bytes.as_slice()
     }
@@ -129,6 +131,7 @@ impl IdCred {
     /// Note that this is NOT doing CBOR encoding, it is rather performing (when applicable)
     /// the compact encoding of ID_CRED fields.
     /// This style of encoding is used when ID_CRED_x has an impact on message size.
+    #[hax_lib::requires(self.bytes.len() <= BUFFER_ID_CRED_LEN)]
     pub fn as_encoded_value(&self) -> &[u8] {
         // This would be idiomatic as a match statement.
         // Workaround-For: https://github.com/hacspec/hax/issues/804
@@ -145,14 +148,17 @@ impl IdCred {
         }
     }
 
+    #[hax_lib::requires(self.bytes.len() >= 2 && self.bytes.len() <= BUFFER_ID_CRED_LEN)]
     pub fn reference_only(&self) -> Result<bool, EDHOCError> {
         Ok(self.item_type()? == IdCredType::KID)
     }
 
+    #[hax_lib::requires(self.bytes.len() >= 2 && self.bytes.len() <= BUFFER_ID_CRED_LEN)]
     fn item_type(&self) -> Result<IdCredType, EDHOCError> {
         self.bytes[1].try_into()
     }
 
+    #[hax_lib::requires(self.bytes.len() >= 2 && self.bytes.len() <= BUFFER_ID_CRED_LEN)]
     pub fn get_ccs(&self) -> Option<Credential> {
         if self.item_type() == Ok(IdCredType::KCCS) {
             Credential::parse_ccs(&self.bytes.as_slice()[2..]).ok()
@@ -185,6 +191,7 @@ pub struct Credential {
     pub cred_type: CredentialType,
 }
 
+#[hax_lib::attributes]
 impl Credential {
     /// Creates a new CCS credential with the given bytes and public key
     pub fn new_ccs(bytes: BufferCred, public_key: BytesKeyEC2) -> Self {
@@ -426,6 +433,7 @@ impl Credential {
     ///
     /// For example, if the credential is a CCS:
     ///   { /kccs/ 14: bytes }
+    #[hax_lib::requires(self.bytes.len() <= BUFFER_CRED_LEN && self.bytes.len() <= BUFFER_ID_CRED_LEN - 2)]
     pub fn by_value(&self) -> Result<IdCred, EDHOCError> {
         match self.cred_type {
             CredentialType::CCS => {
@@ -452,6 +460,7 @@ impl Credential {
     ///   { /kid/ 4: kid }
     ///
     /// TODO: accept a parameter to specify the type of reference, e.g. kid, x5t, etc.
+    #[hax_lib::requires(self.kid.as_ref().map_or(true, |k| k.len() <= BUFFER_KID_LEN && k.len() <= BUFFER_ID_CRED_LEN - 3))]
     pub fn by_kid(&self) -> Result<IdCred, EDHOCError> {
         let Some(kid) = self.kid.as_ref() else {
             return Err(EDHOCError::MissingIdentity);

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -1,0 +1,75 @@
+use core::num::NonZeroI16;
+#[derive(PartialEq, Debug)]
+#[non_exhaustive]
+pub enum EDHOCError {
+    /// In an exchange, a credential was set as "expected", but the credential configured by the
+    /// peer did not match what was presented. This is more an application internal than an EDHOC
+    /// error: When the application sets the expected credential, that process should be informed
+    /// by the known details.
+    UnexpectedCredential,
+    MissingIdentity,
+    IdentityAlreadySet,
+    MacVerificationFailed,
+    UnsupportedMethod,
+    UnsupportedCipherSuite,
+    ParsingError,
+    EncodingError,
+    CredentialTooLongError,
+    EadLabelTooLongError,
+    EadTooLongError,
+    /// An EAD was received that was either not known (and critical), or not understood, or
+    /// otherwise erroneous.
+    EADUnprocessable,
+    /// The credential or EADs could be processed (possibly by a third party), but the decision
+    /// based on that was to not to continue the EDHOC session.
+    ///
+    /// See also
+    /// <https://datatracker.ietf.org/doc/html/draft-ietf-lake-authz#name-edhoc-error-access-denied>
+    AccessDenied,
+}
+
+impl EDHOCError {
+    /// The ERR_CODE corresponding to the error
+    ///
+    /// Errors that refer to internal limitations (such as EadTooLongError) are treated the same
+    /// way as parsing errors, and return an unspecified error: Those are equivalent to limitations
+    /// of the parser, and a constrained system can not be expected to differentiate between "the
+    /// standard allows this but my number space is too small" and "this violates the standard".
+    ///
+    /// If an EDHOCError is returned through EDHOC, it will use this in its EDHOC error message.
+    ///
+    /// Note that this on its own is insufficient to create an error message: Additional ERR_INFO
+    /// is needed, which may or may not be available with the EDHOCError alone.
+    ///
+    /// TODO: Evolve the EDHOCError type such that all information needed is available.
+    pub fn err_code(&self) -> ErrCode {
+        use EDHOCError::*;
+        match self {
+            UnexpectedCredential => ErrCode::UNSPECIFIED,
+            MissingIdentity => ErrCode::UNSPECIFIED,
+            IdentityAlreadySet => ErrCode::UNSPECIFIED,
+            MacVerificationFailed => ErrCode::UNSPECIFIED,
+            UnsupportedMethod => ErrCode::UNSPECIFIED,
+            UnsupportedCipherSuite => ErrCode::WRONG_SELECTED_CIPHER_SUITE,
+            ParsingError => ErrCode::UNSPECIFIED,
+            EncodingError => ErrCode::UNSPECIFIED,
+            CredentialTooLongError => ErrCode::UNSPECIFIED,
+            EadLabelTooLongError => ErrCode::UNSPECIFIED,
+            EadTooLongError => ErrCode::UNSPECIFIED,
+            EADUnprocessable => ErrCode::UNSPECIFIED,
+            AccessDenied => ErrCode::ACCESS_DENIED,
+        }
+    }
+}
+
+/// Representation of an EDHOC ERR_CODE
+#[repr(C)]
+pub struct ErrCode(pub NonZeroI16);
+
+impl ErrCode {
+    pub const UNSPECIFIED: Self = ErrCode(NonZeroI16::new(1).unwrap());
+    pub const WRONG_SELECTED_CIPHER_SUITE: Self = ErrCode(NonZeroI16::new(2).unwrap());
+    pub const UNKNOWN_CREDENTIAL: Self = ErrCode(NonZeroI16::new(3).unwrap());
+    // Code requested in https://datatracker.ietf.org/doc/html/draft-ietf-lake-authz
+    pub const ACCESS_DENIED: Self = ErrCode(NonZeroI16::new(3333).unwrap());
+}

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -1,4 +1,3 @@
-use core::num::NonZeroI16;
 #[derive(PartialEq, Debug)]
 #[non_exhaustive]
 pub enum EDHOCError {
@@ -64,12 +63,12 @@ impl EDHOCError {
 
 /// Representation of an EDHOC ERR_CODE
 #[repr(C)]
-pub struct ErrCode(pub NonZeroI16);
+pub struct ErrCode(pub i16);
 
 impl ErrCode {
-    pub const UNSPECIFIED: Self = ErrCode(NonZeroI16::new(1).unwrap());
-    pub const WRONG_SELECTED_CIPHER_SUITE: Self = ErrCode(NonZeroI16::new(2).unwrap());
-    pub const UNKNOWN_CREDENTIAL: Self = ErrCode(NonZeroI16::new(3).unwrap());
+    pub const UNSPECIFIED: Self = ErrCode(1);
+    pub const WRONG_SELECTED_CIPHER_SUITE: Self = ErrCode(2);
+    pub const UNKNOWN_CREDENTIAL: Self = ErrCode(3);
     // Code requested in https://datatracker.ietf.org/doc/html/draft-ietf-lake-authz
-    pub const ACCESS_DENIED: Self = ErrCode(NonZeroI16::new(3333).unwrap());
+    pub const ACCESS_DENIED: Self = ErrCode(4);
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -27,122 +27,13 @@ pub use cred::*;
 mod buffer;
 pub use buffer::*;
 
+pub mod consts;
+pub use consts::*;
+
 #[cfg(feature = "python-bindings")]
 use pyo3::prelude::*;
 #[cfg(feature = "python-bindings")]
 mod python_bindings;
-
-// When changing this, beware that it is re-implemented in cbindgen.toml
-pub const MAX_MESSAGE_SIZE_LEN: usize = if cfg!(feature = "max_message_size_len_1024") {
-    1024
-} else if cfg!(feature = "max_message_size_len_512") {
-    512
-} else if cfg!(feature = "max_message_size_len_448") {
-    448
-} else if cfg!(feature = "max_message_size_len_384") {
-    384
-} else if cfg!(feature = "max_message_size_len_320") {
-    320
-} else if cfg!(feature = "max_message_size_len_256") {
-    256
-} else {
-    // need 128 to handle EAD fields, and 192 for the EAD_1 voucher
-    128 + 64
-};
-
-pub const ID_CRED_LEN: usize = 4;
-pub const SUITES_LEN: usize = 9;
-pub const SUPPORTED_SUITES_LEN: usize = 1;
-pub const EDHOC_METHOD: u8 = 3u8; // stat-stat is the only supported method
-pub const P256_ELEM_LEN: usize = 32;
-pub const ELEM_LEN_PSK: usize = 16;
-pub const SHA256_DIGEST_LEN: usize = 32;
-pub const AES_CCM_KEY_LEN: usize = 16;
-pub const AES_CCM_IV_LEN: usize = 13;
-pub const AES_CCM_TAG_LEN: usize = 8;
-pub const MAC_LENGTH: usize = 8; // used for EAD Zeroconf
-pub const MAC_LENGTH_2: usize = MAC_LENGTH;
-pub const MAC_LENGTH_3: usize = MAC_LENGTH_2;
-pub const VOUCHER_LEN: usize = MAC_LENGTH;
-pub const MAX_EAD_ITEMS: usize = 4;
-
-// maximum supported length of connection identifier for R
-//
-// When changing this, beware that it is re-implemented in cbindgen.toml
-pub const MAX_KDF_CONTEXT_LEN: usize = if cfg!(feature = "max_kdf_content_len_1024") {
-    1024
-} else if cfg!(feature = "max_kdf_content_len_512") {
-    512
-} else if cfg!(feature = "max_kdf_content_len_448") {
-    448
-} else if cfg!(feature = "max_kdf_content_len_384") {
-    384
-} else if cfg!(feature = "max_kdf_content_len_320") {
-    320
-} else {
-    256
-};
-pub const MAX_KDF_LABEL_LEN: usize = 15; // for "KEYSTREAM_2"
-
-// When changing this, beware that it is re-implemented in cbindgen.toml
-pub const MAX_BUFFER_LEN: usize = if cfg!(feature = "max_buffer_len_1024") {
-    1024
-} else if cfg!(feature = "max_buffer_len_512") {
-    512
-} else if cfg!(feature = "max_buffer_len_448") {
-    448
-} else if cfg!(feature = "max_buffer_len_384") {
-    384
-} else {
-    256 + 64
-};
-pub const CBOR_BYTE_STRING: u8 = 0x58u8;
-pub const CBOR_TEXT_STRING: u8 = 0x78u8;
-pub const CBOR_UINT_1BYTE: u8 = 0x18u8;
-pub const CBOR_NEG_INT_1BYTE_START: u8 = 0x20u8;
-pub const CBOR_NEG_INT_1BYTE_END: u8 = 0x37u8;
-pub const CBOR_UINT_1BYTE_START: u8 = 0x0u8;
-pub const CBOR_UINT_1BYTE_END: u8 = 0x17u8;
-const CBOR_MAJOR_UNSIGNED: u8 = 0 << 5;
-const CBOR_MAJOR_NEGATIVE: u8 = 1 << 5;
-const CBOR_MAJOR_TAG: u8 = 6 << 5;
-const CBOR_MAJOR_FLOATSIMPLE: u8 = 7 << 5;
-pub const CBOR_MAJOR_TEXT_STRING: u8 = 0x60u8;
-pub const CBOR_MAJOR_BYTE_STRING: u8 = 0x40u8;
-pub const CBOR_MAJOR_BYTE_STRING_MAX: u8 = 0x57u8;
-pub const CBOR_MAJOR_ARRAY: u8 = 0x80u8;
-pub const CBOR_MAJOR_ARRAY_MAX: u8 = 0x97u8;
-pub const CBOR_MAJOR_MAP: u8 = 0xA0;
-pub const MAX_INFO_LEN: usize = 2 + SHA256_DIGEST_LEN + // 32-byte digest as bstr
-				            1 + MAX_KDF_LABEL_LEN +     // label <24 bytes as tstr
-						    1 + MAX_KDF_CONTEXT_LEN +   // context <24 bytes as bstr
-						    1; // length as u8
-
-pub const KCCS_LABEL: u8 = 14;
-#[deprecated(note = "Typo for KCCS_LABEL")]
-pub const KCSS_LABEL: u8 = KCCS_LABEL;
-pub const KID_LABEL: u8 = 4;
-
-pub const ENC_STRUCTURE_LEN: usize = 8 + 5 + SHA256_DIGEST_LEN; // 8 for ENCRYPT0
-pub const ENC_STRUCTURE_PSK_LEN: usize = 1 + 1 + 8 + 1 + EXTERNAL_AAD_PSK_LEN; //
-pub const EXTERNAL_AAD_PSK_LEN: usize = 1 + 1 + 2 + 32 + 2 + 38 + 2 + 38 + 1;
-pub const MAX_EAD_LEN: usize = if cfg!(feature = "max_ead_len_1024") {
-    1024
-} else if cfg!(feature = "max_ead_len_768") {
-    768
-} else if cfg!(feature = "max_ead_len_512") {
-    512
-} else if cfg!(feature = "max_ead_len_384") {
-    384
-} else if cfg!(feature = "max_ead_len_256") {
-    256
-} else if cfg!(feature = "max_ead_len_192") {
-    192
-} else if cfg!(feature = "max_ead_len_128") {
-    128
-} else {
-    64
-};
 
 /// Maximum length of a [`ConnId`] (`C_x`).
 ///

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -15,7 +15,6 @@ pub use cbor_decoder::*;
 pub use edhoc_parser::*;
 pub use helpers::*;
 
-use core::num::NonZeroI16;
 use defmt_or_log::trace;
 
 mod crypto;
@@ -29,6 +28,9 @@ pub use buffer::*;
 
 pub mod consts;
 pub use consts::*;
+
+mod error;
+pub use error::{EDHOCError, ErrCode};
 
 #[cfg(feature = "python-bindings")]
 use pyo3::prelude::*;
@@ -292,81 +294,6 @@ impl From<EDHOCSuite> for u8 {
     fn from(suite: EDHOCSuite) -> u8 {
         suite as u8
     }
-}
-
-#[derive(PartialEq, Debug)]
-#[non_exhaustive]
-pub enum EDHOCError {
-    /// In an exchange, a credential was set as "expected", but the credential configured by the
-    /// peer did not match what was presented. This is more an application internal than an EDHOC
-    /// error: When the application sets the expected credential, that process should be informed
-    /// by the known details.
-    UnexpectedCredential,
-    MissingIdentity,
-    IdentityAlreadySet,
-    MacVerificationFailed,
-    UnsupportedMethod,
-    UnsupportedCipherSuite,
-    ParsingError,
-    EncodingError,
-    CredentialTooLongError,
-    EadLabelTooLongError,
-    EadTooLongError,
-    /// An EAD was received that was either not known (and critical), or not understood, or
-    /// otherwise erroneous.
-    EADUnprocessable,
-    /// The credential or EADs could be processed (possibly by a third party), but the decision
-    /// based on that was to not to continue the EDHOC session.
-    ///
-    /// See also
-    /// <https://datatracker.ietf.org/doc/html/draft-ietf-lake-authz#name-edhoc-error-access-denied>
-    AccessDenied,
-}
-
-impl EDHOCError {
-    /// The ERR_CODE corresponding to the error
-    ///
-    /// Errors that refer to internal limitations (such as EadTooLongError) are treated the same
-    /// way as parsing errors, and return an unspecified error: Those are equivalent to limitations
-    /// of the parser, and a constrained system can not be expected to differentiate between "the
-    /// standard allows this but my number space is too small" and "this violates the standard".
-    ///
-    /// If an EDHOCError is returned through EDHOC, it will use this in its EDHOC error message.
-    ///
-    /// Note that this on its own is insufficient to create an error message: Additional ERR_INFO
-    /// is needed, which may or may not be available with the EDHOCError alone.
-    ///
-    /// TODO: Evolve the EDHOCError type such that all information needed is available.
-    pub fn err_code(&self) -> ErrCode {
-        use EDHOCError::*;
-        match self {
-            UnexpectedCredential => ErrCode::UNSPECIFIED,
-            MissingIdentity => ErrCode::UNSPECIFIED,
-            IdentityAlreadySet => ErrCode::UNSPECIFIED,
-            MacVerificationFailed => ErrCode::UNSPECIFIED,
-            UnsupportedMethod => ErrCode::UNSPECIFIED,
-            UnsupportedCipherSuite => ErrCode::WRONG_SELECTED_CIPHER_SUITE,
-            ParsingError => ErrCode::UNSPECIFIED,
-            EncodingError => ErrCode::UNSPECIFIED,
-            CredentialTooLongError => ErrCode::UNSPECIFIED,
-            EadLabelTooLongError => ErrCode::UNSPECIFIED,
-            EadTooLongError => ErrCode::UNSPECIFIED,
-            EADUnprocessable => ErrCode::UNSPECIFIED,
-            AccessDenied => ErrCode::ACCESS_DENIED,
-        }
-    }
-}
-
-/// Representation of an EDHOC ERR_CODE
-#[repr(C)]
-pub struct ErrCode(pub NonZeroI16);
-
-impl ErrCode {
-    pub const UNSPECIFIED: Self = ErrCode(NonZeroI16::new(1).unwrap());
-    pub const WRONG_SELECTED_CIPHER_SUITE: Self = ErrCode(NonZeroI16::new(2).unwrap());
-    pub const UNKNOWN_CREDENTIAL: Self = ErrCode(NonZeroI16::new(3).unwrap());
-    // Code requested in https://datatracker.ietf.org/doc/html/draft-ietf-lake-authz
-    pub const ACCESS_DENIED: Self = ErrCode(NonZeroI16::new(3333).unwrap());
 }
 
 #[derive(Debug)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1177,8 +1177,7 @@ mod cbor_decoder {
         /// Decode a `u8` value.
         pub fn u8(&mut self) -> Result<u8, CBORError> {
             let n = self.read()?;
-            // NOTE: thid could be a `match` with `n @ 0x00..=0x17` clauses but hax doesn't support it
-            if (0..=0x17).contains(&n) {
+            if n <= 0x17 {
                 Ok(n)
             } else if 0x18 == n {
                 self.read()
@@ -1190,14 +1189,20 @@ mod cbor_decoder {
         /// Decode an `i8` value.
         pub fn i8(&mut self) -> Result<i8, CBORError> {
             let n = self.read()?;
-            if (0..=0x17).contains(&n) {
+            if n <= 0x17 {
                 Ok(n as i8)
-            } else if (0x20..=0x37).contains(&n) {
+            } else if n >= 0x20 && n <= 0x37 {
                 Ok(-1 - (n - 0x20) as i8)
             } else if 0x18 == n {
                 Ok(self.read()? as i8)
             } else if 0x38 == n {
-                Ok(-1 - (self.read()? - 0x20) as i8)
+                let b = self.read()?;
+                // -1 - b fits in i8 only when b <= 127 (result -128..-1)
+                if b <= 127 {
+                    Ok(-1 - b as i8)
+                } else {
+                    Err(CBORError::DecodingError)
+                }
             } else {
                 Err(CBORError::DecodingError)
             }
@@ -1207,9 +1212,12 @@ mod cbor_decoder {
         pub fn i32_limited(&mut self) -> Result<i32, CBORError> {
             let (major, argument) = self.read_major_argument16()?;
             match major {
-                CBOR_MAJOR_UNSIGNED => Ok(i32::from(argument)),
+                // u16 always fits in i32
+                CBOR_MAJOR_UNSIGNED => Ok(argument as i32),
                 // Can not underflow
-                CBOR_MAJOR_NEGATIVE => Ok(-1 - i32::from(argument)),
+                // argument as i32 is in 0..=65535, so -1 - argument is in -65536..=-1,
+                // so the subtraction never underflows for i32
+                CBOR_MAJOR_NEGATIVE => Ok(-1 - argument as i32),
                 _ => Err(CBORError::DecodingError),
             }
         }
@@ -1225,8 +1233,8 @@ mod cbor_decoder {
             let value = match info {
                 // Workaround-For: https://github.com/cryspen/hax/issues/925
                 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17
-                | 18 | 19 | 20 | 21 | 22 | 23 => info.into(),
-                24 => self.read()?.into(),
+                | 18 | 19 | 20 | 21 | 22 | 23 => info as u16,
+                24 => self.read()? as u16,
                 25 => u16::from_be_bytes([self.read()?, self.read()?]),
                 // We do not support those in this function.
                 26 | 27 => return Err(CBORError::DecodingError),
@@ -1244,7 +1252,7 @@ mod cbor_decoder {
         /// Get the raw `i8` or `u8` value.
         pub fn int_raw(&mut self) -> Result<u8, CBORError> {
             let n = self.read()?;
-            if (0..=0x17).contains(&n) || (0x20..=0x37).contains(&n) {
+            if n <= 0x17 || n >= 0x20 && n <= 0x37 {
                 Ok(n)
             } else {
                 Err(CBORError::DecodingError)
@@ -1311,10 +1319,10 @@ mod cbor_decoder {
 
         /// Decode a `u8` value into usize.
         pub fn as_usize(&mut self, b: u8) -> Result<usize, CBORError> {
-            if (0..=0x17).contains(&b) {
-                Ok(usize::from(b))
+            if b <= 0x17 {
+                Ok(b as usize)
             } else if 0x18 == b {
-                self.read().map(usize::from)
+                Ok(self.read()? as usize)
             } else {
                 Err(CBORError::DecodingError)
             }
@@ -1327,7 +1335,7 @@ mod cbor_decoder {
 
         /// Get the additionl type info of the given byte (lowest 5 bits).
         pub fn info_of(b: u8) -> u8 {
-            b & 0b000_11111
+            b % 32
         }
 
         /// Check for: an unsigned integer encoded as a single byte
@@ -1375,7 +1383,7 @@ mod cbor_decoder {
                                 .ok_or(CBORError::DecodingError)?;
                         }
                         CBOR_MAJOR_BYTE_STRING | CBOR_MAJOR_TEXT_STRING => {
-                            self.read_slice(argument.into())?;
+                            self.read_slice(argument as usize)?;
                         }
                         CBOR_MAJOR_ARRAY => {
                             remaining_items = remaining_items
@@ -1393,7 +1401,11 @@ mod cbor_decoder {
                 }
             }
 
-            Ok(&self.buf[start..self.position()])
+            // FIXME: we can remove this .ok_or() if we add hax::attributes
+            // that guarantee that self.pos <= self.buf.len()
+            self.buf
+                .get(start..self.position())
+                .ok_or(CBORError::DecodingError)
         }
     }
 }


### PR DESCRIPTION


- hax doesn't accept contains (Identifier impl_10__contains not found in module Core_models.Ops.Range) also looks like he doesnt like when we do safe conversions between integers (`from`, `into`) he prefer `as` change bitwise and for a modulus
- **fix bug where we incorrectly decoded some i8**
- add an unnecessary check with ok_or.
- **fix the bug where we could create a IdCred where self.bytes[1] is not 4 or 14, it would panic!**
- help cred functions with annotations (maybe this can be fixed with hax_attributes (FIXME)